### PR TITLE
remove dist tag in rpm filename (el9, ...)

### DIFF
--- a/prometheus-cvmfs-exporter.spec
+++ b/prometheus-cvmfs-exporter.spec
@@ -1,6 +1,6 @@
 Name:           prometheus-cvmfs-exporter
 Version:        %{version}
-Release:        %{release}%{?dist}
+Release:        %{release}
 Summary:        Prometheus exporter for CVMFS client monitoring
 
 License:        BSD-3-Clause


### PR DESCRIPTION
So the packagename is prometheus-cvmfs-exporter-1.0.0-1.noarch.rpm . The rpm should work for all distros.