### PR TITLE
fix metric naming for cvmfs 2.13.3

### DIFF
--- a/cvmfs-client-prometheus.sh
+++ b/cvmfs-client-prometheus.sh
@@ -660,8 +660,8 @@ for REPO in $REPO_LIST; do
     $METRICS_FUNCTION "${REPO}"
 done
 
-# Apply postprocessing for version 2.13.2 to rename metrics for consistency
-if check_cvmfs_version_exact; then
+# Apply postprocessing for version >= 2.13.2 to rename metrics for consistency
+if check_cvmfs_version; then
     postprocess_metrics_for_2132
 fi
 


### PR DESCRIPTION
Fixes #23

The post-processing step for metric naming was limited to cvmfs 2.13.2 only.

Newer versions skip the renaming logic and emit legacy metric names.

This causes mismatch with dashboards expecting categorized metrics `cvmfs_net_*`, `cvmfs_sys_*`

This change extends the condition to apply post-processing for all versions >= 2.13.2